### PR TITLE
routes: do not override response headers

### DIFF
--- a/dash_auth_external/routes.py
+++ b/dash_auth_external/routes.py
@@ -128,7 +128,7 @@ def make_access_token_route(
         token = response_data[_token_field_name]
 
         response = redirect(_home_suffix)
-        response.headers = {_token_field_name: token}
+        response.headers.add(_token_field_name, token)
         return response
 
     return app


### PR DESCRIPTION
Response headers in dash-2.4 is not a dictionary but Headers.
It also not ideal to override the member but amend values.

  File "/home/alonbl/.local/lib/python3.10/site-packages/flask/app.py", line 1889, in process_response
    response = self.ensure_sync(func)(response)
  File "/home/alonbl/.local/lib/python3.10/site-packages/dash/dash.py", line 1820, in _after_request
    response.headers.add("Server-Timing", value)
AttributeError: 'dict' object has no attribute 'add'

Signed-off-by: Alon Bar-Lev <alon.barlev@gmail.com>